### PR TITLE
Fix ES module directory import errors for Node.js compatibility

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -174,7 +174,7 @@
     "build": "pnpm clean && pnpm lint && pnpm build:types && pnpm build:cjs && pnpm build:esm && pnpm build:css",
     "build:types": "tsc -p tsconfig.cjs.json --emitDeclarationOnly --declarationDir dist/types",
     "build:cjs": "tsc -p tsconfig.cjs.json --outDir dist/cjs --module commonjs && tsc-alias -p tsconfig.cjs.json --outDir dist/cjs && mkdir -p dist/cjs/generated && cp src/generated/chain-networks.json dist/cjs/generated/",
-    "build:esm": "tsc -p tsconfig.esm.json --outDir dist/esm --module esnext  && tsc-alias -p tsconfig.esm.json --outDir dist/esm && mkdir -p dist/esm/generated && cp src/generated/chain-networks.json dist/esm/generated/",
+    "build:esm": "tsc -p tsconfig.esm.json --outDir dist/esm --module esnext  && tsc-alias -p tsconfig.esm.json --outDir dist/esm && mkdir -p dist/esm/generated && cp src/generated/chain-networks.json dist/esm/generated/ && node scripts/fix-esm-imports.js",
     "build:css": "postcss src/styles/index.css -o dist/styles/index.css",
     "dev:cjs": "tsc-watch -p tsconfig.cjs.json --onSuccess \"tsc-alias -p tsconfig.cjs.json --outDir dist/cjs\"",
     "dev:esm": "tsc-watch -p tsconfig.esm.json --onSuccess \"tsc-alias -p tsconfig.esm.json --outDir dist/esm\"",

--- a/packages/sdk/scripts/fix-esm-imports.js
+++ b/packages/sdk/scripts/fix-esm-imports.js
@@ -1,0 +1,67 @@
+const fs = require("fs");
+const path = require("path");
+
+function fixEsmImports(dir) {
+  const files = fs.readdirSync(dir);
+
+  files.forEach(file => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat.isDirectory()) {
+      fixEsmImports(filePath);
+    } else if (file.endsWith(".js")) {
+      let content = fs.readFileSync(filePath, "utf-8");
+
+      // Fix relative imports that don't have extensions
+      content = content.replace(/from\s+["'](\.\.?\/.*?)["']/g, (match, importPath) => {
+        // Skip if already has extension
+        if (importPath.endsWith(".js") || importPath.endsWith(".json")) {
+          return match;
+        }
+
+        // Check if it's a directory import (needs /index.js)
+        const fullPath = path.resolve(path.dirname(filePath), importPath);
+        const indexPath = path.join(fullPath, "index.js");
+
+        if (fs.existsSync(indexPath)) {
+          return match.replace(importPath, `${importPath}/index.js`);
+        } else if (fs.existsSync(`${fullPath}.js`)) {
+          return match.replace(importPath, `${importPath}.js`);
+        }
+
+        return match;
+      });
+
+      // Fix export statements
+      content = content.replace(/export\s+\*\s+from\s+["'](\.\.?\/.*?)["']/g, (match, importPath) => {
+        // Skip if already has extension
+        if (importPath.endsWith(".js") || importPath.endsWith(".json")) {
+          return match;
+        }
+
+        // Check if it's a directory import (needs /index.js)
+        const fullPath = path.resolve(path.dirname(filePath), importPath);
+        const indexPath = path.join(fullPath, "index.js");
+
+        if (fs.existsSync(indexPath)) {
+          return match.replace(importPath, `${importPath}/index.js`);
+        } else if (fs.existsSync(`${fullPath}.js`)) {
+          return match.replace(importPath, `${importPath}.js`);
+        }
+
+        return match;
+      });
+
+      fs.writeFileSync(filePath, content);
+    }
+  });
+}
+
+// Fix ESM imports in the dist/esm directory
+const esmDir = path.join(__dirname, "../dist/esm");
+if (fs.existsSync(esmDir)) {
+  console.log("Fixing ESM imports...");
+  fixEsmImports(esmDir);
+  console.log("ESM imports fixed!");
+}

--- a/packages/sdk/src/anyspend/index.ts
+++ b/packages/sdk/src/anyspend/index.ts
@@ -22,5 +22,3 @@ export * from "./constants";
 // Abis
 export * from "./abis/abi-usdc-base";
 export * from "./abis/erc20-staking";
-
-console.log(`Test CICD`);

--- a/packages/sdk/src/shared/constants/chains/supported.ts
+++ b/packages/sdk/src/shared/constants/chains/supported.ts
@@ -34,8 +34,8 @@ invariant(b3Testnet, "B3 testnet chain not found in supported chains");
 export const baseMainnet = supportedChains.find(chain => chain.id === 8453);
 invariant(baseMainnet, "Base mainnet chain not found in supported chains");
 
-export const b3MainnetThirdWeb = supportedChainsTW.find(chain => chain.id === 8333)!;
+export const b3MainnetThirdWeb: ThirdwebChain = supportedChainsTW.find(chain => chain.id === 8333)!;
 invariant(b3MainnetThirdWeb, "B3 mainnet chain not found in supported chains TW");
 
-export const b3TestnetThirdWeb = supportedChainsTW.find(chain => chain.id === 1993)!;
+export const b3TestnetThirdWeb: ThirdwebChain = supportedChainsTW.find(chain => chain.id === 1993)!;
 invariant(b3TestnetThirdWeb, "B3 testnet chain not found in supported chains TW");


### PR DESCRIPTION
Resolves error:
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import 'node_modules/@b3dotfun/sdk/dist/esm/anyspend/react/hooks' is not supported resolving ES modules imported from node_modules/@b3dotfun/sdk/dist/esm/anyspend/index.js

- Create post-build script to automatically add .js extensions to ESM imports
- Update build process to run fix-esm-imports.js after ESM compilation
- Handle both ./ and ../ relative imports in compiled JavaScript files
- Keep source TypeScript files clean without verbose .js extensions