### PR TITLE
Update B3DynamicModal to use overflow-y-auto for scrolling behavior

### DIFF
--- a/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
+++ b/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
@@ -508,7 +508,7 @@ export function AnySpendCustom({
   const orderDetailsView = (
     <div
       className={cn(
-        "mx-auto flex w-full flex-col items-center gap-4 p-5",
+        "mx-auto flex max-h-[90dvh] w-full flex-col items-center gap-4 overflow-y-auto p-5",
         mode === "modal" && "bg-b3-react-background"
       )}
     >

--- a/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
+++ b/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
@@ -17,26 +17,27 @@ import {
   useAnyspendTokenList,
   useGeoOnrampOptions
 } from "@b3dotfun/sdk/anyspend";
-import { useB3, StyleRoot } from "@b3dotfun/sdk/global-account/react";
 import {
   Badge,
   Button,
   ShinyButton,
   Skeleton,
+  StyleRoot,
   Tabs,
   TabsContent,
   TabsList,
   TabTrigger,
+  TextShimmer,
+  TransitionPanel,
   useAccountWallet,
+  useB3,
   useBsmntProfile,
   useHasMounted,
-  useRouter,
-  useTokenBalancesByChain,
   useModalStore,
-  useSearchParamsSSR
+  useRouter,
+  useSearchParamsSSR,
+  useTokenBalancesByChain
 } from "@b3dotfun/sdk/global-account/react";
-import { TextShimmer } from "@b3dotfun/sdk/global-account/react";
-import { TransitionPanel } from "@b3dotfun/sdk/global-account/react";
 import { cn } from "@b3dotfun/sdk/shared/utils";
 import centerTruncate from "@b3dotfun/sdk/shared/utils/centerTruncate";
 import { formatTokenAmount } from "@b3dotfun/sdk/shared/utils/number";
@@ -626,7 +627,7 @@ export function AnySpendCustom({
       <Tabs
         value={activeTab}
         onValueChange={value => setActiveTab(value as "crypto" | "fiat")}
-        className="bg-b3-react-background w-full p-5"
+        className="bg-b3-react-background max-h-[60dvh] w-full overflow-y-auto p-5"
       >
         {/* Only show tabs when geo onramp has been properly initialized */}
         {isOnrampSupported || activeTab === "fiat" ? (

--- a/packages/sdk/src/global-account/react/components/B3DynamicModal.tsx
+++ b/packages/sdk/src/global-account/react/components/B3DynamicModal.tsx
@@ -101,7 +101,7 @@ export function B3DynamicModal() {
       <ModalContent className={contentClass} hideCloseButton={hideCloseButton}>
         <ModalTitle className="sr-only hidden">{contentType?.type || "Modal"}</ModalTitle>
         <ModalDescription className="sr-only hidden">{contentType?.type || "Modal Body"}</ModalDescription>
-        <div className="overflow-y-auto">
+        <div className="overflow-hidden">
           {history.length > 0 && contentType?.showBackButton && (
             <button
               onClick={navigateBack}

--- a/packages/sdk/src/global-account/react/components/B3DynamicModal.tsx
+++ b/packages/sdk/src/global-account/react/components/B3DynamicModal.tsx
@@ -101,7 +101,7 @@ export function B3DynamicModal() {
       <ModalContent className={contentClass} hideCloseButton={hideCloseButton}>
         <ModalTitle className="sr-only hidden">{contentType?.type || "Modal"}</ModalTitle>
         <ModalDescription className="sr-only hidden">{contentType?.type || "Modal Body"}</ModalDescription>
-        <div className="overflow-hidden">
+        <div className="overflow-y-auto">
           {history.length > 0 && contentType?.showBackButton && (
             <button
               onClick={navigateBack}


### PR DESCRIPTION
https://linear.app/npclabs/issue/B3-1961/anyspend-dogfooding-16-june-2025-ios-safari-cant-scroll-or-proceed

## Description

Write a description.

## Test Plan

- [ ] Locally
- [ ] Unit Tests
- [ ] Manually
- [ ] CI/CD

## Screenshots

For BE, include snippets, response payloads and/or curl commands to test endpoints

### [FE] Before
<img width="418" alt="Screenshot 2025-07-07 at 4 24 14 PM" src="https://github.com/user-attachments/assets/df9b71b7-28ec-4305-a73f-24008bc7bce7" />

### [FE] After
https://github.com/user-attachments/assets/e49d49ee-ee05-48ac-8535-017a103a3cb2


### [BE] Snippets/Response/Curl

---

## automerge=false
