### PR TITLE
useB3EnsName hook with register and get

### DIFF
--- a/packages/sdk/src/global-account/react/hooks/useB3EnsName.ts
+++ b/packages/sdk/src/global-account/react/hooks/useB3EnsName.ts
@@ -1,37 +1,42 @@
 import bsmntApp from "@b3dotfun/sdk/global-account/bsmnt";
 import { B3_AUTH_COOKIE_NAME } from "@b3dotfun/sdk/shared/constants";
-import Cookies from 'js-cookie';
-import { useCallback } from 'react';
-
+import Cookies from "js-cookie";
+import { useCallback } from "react";
 
 export const useB3EnsName = () => {
-  const registerEns = useCallback(async (username: string, message: string, hash: string)=> {
-    if (!bsmntApp.authentication.authenticated) {
-      await bsmntApp.authentication.authenticate({
-        strategy: 'b3-jwt',
-        accessToken: Cookies.get(B3_AUTH_COOKIE_NAME) || ''
-      });
-    }
+  const registerEns = useCallback(
+    async (username: string, message: string, hash: string) => {
+      if (!bsmntApp.authentication.authenticated) {
+        await bsmntApp.authentication.authenticate({
+          strategy: "b3-jwt",
+          accessToken: Cookies.get(B3_AUTH_COOKIE_NAME) || ""
+        });
+      }
 
-    const response = await bsmntApp.service('profiles').registerUsername({
-      username,
-      message,
-      hash
-    }, {});
+      const response = await bsmntApp.service("profiles").registerUsername(
+        {
+          username,
+          message,
+          hash
+        },
+        {}
+      );
 
-    return response;
-  }, [bsmntApp.authentication.authenticated]);
+      return response;
+    },
+    [bsmntApp.authentication.authenticated]
+  );
 
-  const getEns = useCallback(async (address: string)=> {
+  const getEns = useCallback(async (address: string) => {
     const response = await fetch(`https://ens-gateway.b3.fun/address/${address}`);
-    
+
     if (!response.ok) {
       throw new Error(`Failed to fetch ENS name: ${response.statusText}`);
     }
-    
+
     const data = await response.json();
-    return data as {name: string};
-  }, [])
+    return data as { name: string };
+  }, []);
 
   return {
     registerEns,

--- a/packages/sdk/src/global-account/react/hooks/useB3EnsName.ts
+++ b/packages/sdk/src/global-account/react/hooks/useB3EnsName.ts
@@ -1,0 +1,40 @@
+import bsmntApp from "@b3dotfun/sdk/global-account/bsmnt";
+import { B3_AUTH_COOKIE_NAME } from "@b3dotfun/sdk/shared/constants";
+import Cookies from 'js-cookie';
+import { useCallback } from 'react';
+
+
+export const useB3EnsName = () => {
+  const registerEns = useCallback(async (username: string, message: string, hash: string)=> {
+    if (!bsmntApp.authentication.authenticated) {
+      await bsmntApp.authentication.authenticate({
+        strategy: 'b3-jwt',
+        accessToken: Cookies.get(B3_AUTH_COOKIE_NAME) || ''
+      });
+    }
+
+    const response = await bsmntApp.service('profiles').registerUsername({
+      username,
+      message,
+      hash
+    }, {});
+
+    return response;
+  }, [bsmntApp.authentication.authenticated]);
+
+  const getEns = useCallback(async (address: string)=> {
+    const response = await fetch(`https://ens-gateway.b3.fun/address/${address}`);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ENS name: ${response.statusText}`);
+    }
+    
+    const data = await response.json();
+    return data as {name: string};
+  }, [])
+
+  return {
+    registerEns,
+    getEns
+  };
+};


### PR DESCRIPTION
Hook offering:
- `registerEns`: authenticates with bsmnt using the b3 jwt and then calls the register API on bsmnt
- `getEns`: query the ens of any address