### PR TITLE
update anyspend url

### DIFF
--- a/packages/sdk/src/anyspend/README.md
+++ b/packages/sdk/src/anyspend/README.md
@@ -300,21 +300,12 @@ const order = await anyspendService.createOrder({
 });
 ```
 
-## 🔧 Environment Configuration
-
-### Environment Variables
-
-```bash
-# Optional: Custom AnySpend API endpoints
-NEXT_PUBLIC_ANYSPEND_BASE_URL=https://your-custom-anyspend-api.com
-```
-
 ### Network Configuration
 
 AnySpend automatically configures API endpoints based on the `isMainnet` parameter:
 
-- **Mainnet**: `https://anyspend-mainnet.up.railway.app`
-- **Testnet**: `https://anyspend-testnet.up.railway.app`
+- **Mainnet**: `https://mainnet.anyspend.com`
+- **Testnet**: `http://testnet.anyspend.com`
 
 ## 💼 Common Use Cases
 

--- a/packages/sdk/src/anyspend/constants/index.ts
+++ b/packages/sdk/src/anyspend/constants/index.ts
@@ -2,9 +2,9 @@ import { NftContract, Token } from "@b3dotfun/sdk/anyspend/types";
 import { base } from "viem/chains";
 
 export const ANYSPEND_MAINNET_BASE_URL =
-  process.env.NEXT_PUBLIC_ANYSPEND_BASE_URL || "https://anyspend-mainnet.up.railway.app";
+  process.env.NEXT_PUBLIC_ANYSPEND_BASE_URL || "https://mainnet.anyspend.com";
 export const ANYSPEND_TESTNET_BASE_URL =
-  process.env.NEXT_PUBLIC_ANYSPEND_BASE_URL || "https://anyspend-testnet.up.railway.app";
+  process.env.NEXT_PUBLIC_ANYSPEND_BASE_URL || "https://testnet.anyspend.com";
 
 export const RELAY_ETH_ADDRESS = "0x0000000000000000000000000000000000000000";
 export const RELAY_SOL_ADDRESS = "11111111111111111111111111111111";

--- a/packages/sdk/src/anyspend/constants/index.ts
+++ b/packages/sdk/src/anyspend/constants/index.ts
@@ -1,10 +1,8 @@
 import { NftContract, Token } from "@b3dotfun/sdk/anyspend/types";
 import { base } from "viem/chains";
 
-export const ANYSPEND_MAINNET_BASE_URL =
-  process.env.NEXT_PUBLIC_ANYSPEND_BASE_URL || "https://mainnet.anyspend.com";
-export const ANYSPEND_TESTNET_BASE_URL =
-  process.env.NEXT_PUBLIC_ANYSPEND_BASE_URL || "https://testnet.anyspend.com";
+export const ANYSPEND_MAINNET_BASE_URL = process.env.NEXT_PUBLIC_ANYSPEND_BASE_URL || "https://mainnet.anyspend.com";
+export const ANYSPEND_TESTNET_BASE_URL = process.env.NEXT_PUBLIC_ANYSPEND_BASE_URL || "https://testnet.anyspend.com";
 
 export const RELAY_ETH_ADDRESS = "0x0000000000000000000000000000000000000000";
 export const RELAY_SOL_ADDRESS = "11111111111111111111111111111111";


### PR DESCRIPTION
## Summary
This PR updates the AnySpend SDK by modifying the API endpoint URLs.

## Changes
• Updated AnySpend API base URLs for both mainnet and testnet environments to new domains (`https://mainnet.anyspend.com` and `http://testnet.anyspend.com`).