### PR TITLE
add nft type to mint nft

### DIFF
--- a/packages/sdk/src/anyspend/types/nft.ts
+++ b/packages/sdk/src/anyspend/types/nft.ts
@@ -28,6 +28,8 @@ export type Nft = z.infer<typeof zNft>;
 
 export const zMintNftPayload = z.object({
   contractAddress: z.string(),
+  tokenId: z.number(),
+  contractType: z.nativeEnum(NftType),
   nftPrice: z.string()
 });
 

--- a/packages/sdk/src/anyspend/types/nft.ts
+++ b/packages/sdk/src/anyspend/types/nft.ts
@@ -28,7 +28,7 @@ export type Nft = z.infer<typeof zNft>;
 
 export const zMintNftPayload = z.object({
   contractAddress: z.string(),
-  tokenId: z.number(),
+  tokenId: z.number().nullable(),
   contractType: z.nativeEnum(NftType),
   nftPrice: z.string()
 });


### PR DESCRIPTION
## Summary
This PR introduces the ability to mint NFTs by adding a new NFT type to the minting process and updates the configuration for local development. It also includes various adjustments to the SDK versioning and component properties.

## Changes
• Added `tokenId` and `contractType` fields to the NFT minting payload schema to support NFT minting functionality.  