### PR TITLE
add tokenId and contractType for get quote

### DIFF
--- a/packages/sdk/src/anyspend/types/req-res/getQuote.ts
+++ b/packages/sdk/src/anyspend/types/req-res/getQuote.ts
@@ -1,9 +1,10 @@
 import { QuoteDetails } from "@reservoir0x/relay-sdk";
 import { z } from "zod";
 
+import { zCustomPayload } from "../custom";
+import { NftType } from "../nft";
 import { OrderType } from "../order";
 import { TradeType } from "../relay";
-import { zCustomPayload } from "../custom";
 
 const zGetQuoteBody = z.object({
   srcChain: z.number(),
@@ -21,6 +22,8 @@ const zGetQuoteForSwapOrderBody = zGetQuoteBody.extend({
 const zGetQuoteForMintNftOrderBody = zGetQuoteBody.extend({
   type: z.literal(OrderType.MintNFT),
   contractAddress: z.string(),
+  tokenId: z.number().nullable(),
+  contractType: z.nativeEnum(NftType),
   price: z.string()
 });
 


### PR DESCRIPTION
## Summary
This PR enhances the `getQuote` functionality by adding support for `tokenId` and `contractType`, improving the API's capability to handle NFT-related quotes.

## Changes
• Added `tokenId` and `contractType` fields to the `zGetQuoteForMintNftOrderBody` schema for better NFT quote handling.  
• Updated the schema to include `tokenId` as a nullable number and `contractType` as an enum of `NftType`.  