### PR TITLE
Add sign in to demo app

### DIFF
--- a/apps/anyspend-demo-nextjs/src/app/components/SignInButton.tsx
+++ b/apps/anyspend-demo-nextjs/src/app/components/SignInButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { SignInWithB3, useAccountWallet, useModalStore, useOnchainName } from "@b3dotfun/sdk/global-account/react";
+import { cn } from "@b3dotfun/sdk/shared/utils/cn";
+import { shortenAddress } from "@b3dotfun/sdk/shared/utils/formatAddress";
+import { b3 } from "viem/chains";
+
+export function SignInButton() {
+  const { address, wallet } = useAccountWallet();
+  const { name: ensName } = useOnchainName(address);
+  const { setB3ModalOpen, setB3ModalContentType } = useModalStore();
+
+  const b3Config = {
+    chain: {
+      ...b3,
+      rpc: "https://mainnet-rpc.b3.fun",
+      blockExplorers: [{ name: "B3 Explorer", url: "https://explorer.b3.fun/" }],
+      testnet: undefined,
+    },
+    partnerId: String(process.env.NEXT_PUBLIC_GLOBAL_ACCOUNTS_PARTNER_ID),
+    closeAfterLogin: true,
+    loginWithSiwe: true,
+    withLogo: true,
+  };
+
+  const handleManageAccount = () => {
+    setB3ModalContentType({
+      ...b3Config,
+      type: "manageAccount",
+    });
+    setB3ModalOpen(true);
+  };
+
+  return (
+    <div className="fixed right-4 top-4 z-[100]">
+      <div className="relative flex items-center gap-2">
+        {address ? (
+          <button
+            onClick={handleManageAccount}
+            type="button"
+            className={cn(
+              "relative flex items-center gap-2 rounded-full bg-black/80 px-4 py-2",
+              "text-sm font-medium text-white hover:bg-black/60",
+              "ring-1 ring-white/20 backdrop-blur",
+            )}
+          >
+            <div className="relative flex items-center gap-2">
+              {wallet?.meta?.icon ? (
+                <img src={wallet.meta.icon} alt="Profile" className="h-6 w-6 rounded-full" />
+              ) : (
+                <div className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-500">
+                  <span className="text-xs font-medium text-white">{address.slice(2, 4).toUpperCase()}</span>
+                </div>
+              )}
+              <span className="relative z-10 min-w-[80px] text-white">{ensName || shortenAddress(address)}</span>
+            </div>
+          </button>
+        ) : (
+          <SignInWithB3 {...b3Config} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/anyspend-demo-nextjs/src/app/page.tsx
+++ b/apps/anyspend-demo-nextjs/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { B3_TOKEN, NftType, USDC_BASE } from "@b3dotfun/sdk/anyspend";
 import { useModalStore } from "@b3dotfun/sdk/global-account/react";
 import { base } from "viem/chains";
+import { SignInButton } from "./components/SignInButton";
 
 export default function Home() {
   const setB3ModalOpen = useModalStore(state => state.setB3ModalOpen);
@@ -27,12 +28,12 @@ export default function Home() {
         tokenId: randomTokenId,
         type: NftType.ERC1155,
       },
-      recipientAddress: "0xD32b34E2E55c7005b6506370857bdE4cFD057fC4",
     });
   };
 
   return (
-    <div className="min-h-screen bg-[#FAFAFA]">
+    <div className="relative min-h-screen bg-[#FAFAFA]">
+      <SignInButton />
       <div className="container mx-auto px-6 py-16">
         <div className="mx-auto max-w-6xl">
           <h1 className="mb-4 text-center text-3xl font-bold text-gray-800">AnySpend Demo</h1>

--- a/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
+++ b/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
@@ -488,50 +488,51 @@ export function AnySpendCustom({
     }
   };
 
-  const recipientSection = showRecipient && isAuthenticated && recipientAddress ? (
-    <motion.div
-      initial={false}
-      animate={{
-        opacity: hasMounted ? 1 : 0,
-        y: hasMounted ? 0 : 20,
-        filter: hasMounted ? "blur(0px)" : "blur(10px)",
-      }}
-      transition={{ duration: 0.3, delay: 0.2, ease: "easeInOut" }}
-      className="flex w-full items-center justify-between gap-4"
-    >
-      <div className="text-b3-react-foreground">
-        {orderType === OrderType.Swap
-          ? "Recipient"
-          : orderType === OrderType.MintNFT
-            ? "Receive NFT at"
-            : orderType === OrderType.JoinTournament
-              ? "Join for"
-              : "Recipient"}
-      </div>
-      <div>
-        <Button
-          variant="outline"
-          className="w-full justify-between border-none p-0"
-          onClick={() => setIsRecipientModalOpen(true)}
-        >
-          <div className="flex items-center gap-2">
-            {recipientImageUrl && (
-              <img
-                src={recipientImageUrl}
-                alt={recipientImageUrl}
-                className="bg-b3-react-foreground size-7 rounded-full object-cover opacity-100"
-              />
-            )}
-            <div className="flex flex-col items-start gap-1">
-              {recipientEnsName && <span>@{recipientEnsName}</span>}
-              <span>{centerTruncate(recipientAddress)}</span>
+  const recipientSection =
+    showRecipient && isAuthenticated && recipientAddress ? (
+      <motion.div
+        initial={false}
+        animate={{
+          opacity: hasMounted ? 1 : 0,
+          y: hasMounted ? 0 : 20,
+          filter: hasMounted ? "blur(0px)" : "blur(10px)",
+        }}
+        transition={{ duration: 0.3, delay: 0.2, ease: "easeInOut" }}
+        className="flex w-full items-center justify-between gap-4"
+      >
+        <div className="text-b3-react-foreground">
+          {orderType === OrderType.Swap
+            ? "Recipient"
+            : orderType === OrderType.MintNFT
+              ? "Receive NFT at"
+              : orderType === OrderType.JoinTournament
+                ? "Join for"
+                : "Recipient"}
+        </div>
+        <div>
+          <Button
+            variant="outline"
+            className="w-full justify-between border-none p-0"
+            onClick={() => setIsRecipientModalOpen(true)}
+          >
+            <div className="flex items-center gap-2">
+              {recipientImageUrl && (
+                <img
+                  src={recipientImageUrl}
+                  alt={recipientImageUrl}
+                  className="bg-b3-react-foreground size-7 rounded-full object-cover opacity-100"
+                />
+              )}
+              <div className="flex flex-col items-start gap-1">
+                {recipientEnsName && <span>@{recipientEnsName}</span>}
+                <span>{centerTruncate(recipientAddress)}</span>
+              </div>
             </div>
-          </div>
-          <ChevronRightCircle className="ml-2 size-4 shrink-0 opacity-50" />
-        </Button>
-      </div>
-    </motion.div>
-  ) : null;
+            <ChevronRightCircle className="ml-2 size-4 shrink-0 opacity-50" />
+          </Button>
+        </div>
+      </motion.div>
+    ) : null;
 
   const historyView = (
     <div

--- a/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
+++ b/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
@@ -43,6 +43,9 @@ import {
   useRouter,
   useSearchParamsSSR,
   useTokenBalancesByChain,
+  Dialog,
+  DialogContent,
+  Input,
 } from "@b3dotfun/sdk/global-account/react";
 import { cn } from "@b3dotfun/sdk/shared/utils";
 import centerTruncate from "@b3dotfun/sdk/shared/utils/centerTruncate";
@@ -203,15 +206,17 @@ export function AnySpendCustom({
   // Get current user's wallet
   const currentWallet = useAccountWallet();
 
-  const recipientPropsProfile = useBsmntProfile({ address: recipientAddressProps });
+  // Add state for recipient modal
+  const [isRecipientModalOpen, setIsRecipientModalOpen] = useState(false);
 
-  const recipientAddress = recipientAddressProps || currentWallet.address;
-  const recipientEnsName = recipientAddressProps
-    ? recipientPropsProfile.data?.username?.replaceAll(".b3.fun", "")
-    : currentWallet.ensName;
-  const recipientImageUrl = recipientAddressProps
-    ? recipientPropsProfile.data?.avatar
-    : currentWallet.wallet.meta?.icon;
+  // Add state for custom recipient
+  const [customRecipientAddress, setCustomRecipientAddress] = useState<string | undefined>(recipientAddressProps);
+
+  // Update recipient logic to use custom recipient
+  const recipientAddress = customRecipientAddress || currentWallet.address;
+  const recipientPropsProfile = useBsmntProfile({ address: recipientAddress });
+  const recipientEnsName = recipientPropsProfile.data?.username?.replaceAll(".b3.fun", "");
+  const recipientImageUrl = recipientPropsProfile.data?.avatar || currentWallet.wallet.meta?.icon;
 
   const [orderId, setOrderId] = useState<string | undefined>(loadOrder);
 
@@ -483,47 +488,50 @@ export function AnySpendCustom({
     }
   };
 
-  const recipientSection =
-    showRecipient && isAuthenticated && recipientAddress ? (
-      <motion.div
-        initial={false}
-        animate={{
-          opacity: hasMounted ? 1 : 0,
-          y: hasMounted ? 0 : 20,
-          filter: hasMounted ? "blur(0px)" : "blur(10px)",
-        }}
-        transition={{ duration: 0.3, delay: 0.2, ease: "easeInOut" }}
-        className="flex w-full items-center justify-between gap-4"
-      >
-        <div className="text-b3-react-foreground">
-          {orderType === OrderType.Swap
-            ? "Recipient"
-            : orderType === OrderType.MintNFT
-              ? "Receive NFT at"
-              : orderType === OrderType.JoinTournament
-                ? "Join for"
-                : "Recipient"}
-        </div>
-        <div>
-          <Button variant="outline" className="w-full justify-between border-none p-0">
-            <div className="flex items-center gap-2">
-              {recipientImageUrl && (
-                <img
-                  src={recipientImageUrl}
-                  alt={recipientImageUrl}
-                  className="bg-b3-react-foreground size-7 rounded-full object-cover opacity-100"
-                />
-              )}
-              <div className="flex flex-col items-start gap-1">
-                {recipientEnsName && <span>@{recipientEnsName}</span>}
-                <span>{centerTruncate(recipientAddress)}</span>
-              </div>
+  const recipientSection = showRecipient && isAuthenticated && recipientAddress ? (
+    <motion.div
+      initial={false}
+      animate={{
+        opacity: hasMounted ? 1 : 0,
+        y: hasMounted ? 0 : 20,
+        filter: hasMounted ? "blur(0px)" : "blur(10px)",
+      }}
+      transition={{ duration: 0.3, delay: 0.2, ease: "easeInOut" }}
+      className="flex w-full items-center justify-between gap-4"
+    >
+      <div className="text-b3-react-foreground">
+        {orderType === OrderType.Swap
+          ? "Recipient"
+          : orderType === OrderType.MintNFT
+            ? "Receive NFT at"
+            : orderType === OrderType.JoinTournament
+              ? "Join for"
+              : "Recipient"}
+      </div>
+      <div>
+        <Button
+          variant="outline"
+          className="w-full justify-between border-none p-0"
+          onClick={() => setIsRecipientModalOpen(true)}
+        >
+          <div className="flex items-center gap-2">
+            {recipientImageUrl && (
+              <img
+                src={recipientImageUrl}
+                alt={recipientImageUrl}
+                className="bg-b3-react-foreground size-7 rounded-full object-cover opacity-100"
+              />
+            )}
+            <div className="flex flex-col items-start gap-1">
+              {recipientEnsName && <span>@{recipientEnsName}</span>}
+              <span>{centerTruncate(recipientAddress)}</span>
             </div>
-            <ChevronRightCircle className="ml-2 size-4 shrink-0 opacity-50" />
-          </Button>
-        </div>
-      </motion.div>
-    ) : null;
+          </div>
+          <ChevronRightCircle className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </div>
+    </motion.div>
+  ) : null;
 
   const historyView = (
     <div
@@ -864,6 +872,32 @@ export function AnySpendCustom({
           </div>,
         ]}
       </TransitionPanel>
+
+      {/* Add EnterRecipientModal */}
+      <Dialog open={isRecipientModalOpen} onOpenChange={setIsRecipientModalOpen}>
+        <DialogContent className="w-[420px] max-w-[calc(100vw-32px)] rounded-2xl p-3.5">
+          <div className="flex flex-col gap-3">
+            <div className="text-as-primary font-semibold">To address</div>
+            <Input
+              value={customRecipientAddress || ""}
+              onChange={e => setCustomRecipientAddress(e.target.value)}
+              placeholder="Enter address"
+              className="h-12 rounded-lg"
+              spellCheck={false}
+            />
+            <ShinyButton
+              accentColor={"hsl(var(--as-brand))"}
+              textColor="text-white"
+              className="w-full rounded-lg"
+              onClick={() => {
+                setIsRecipientModalOpen(false);
+              }}
+            >
+              Save
+            </ShinyButton>
+          </div>
+        </DialogContent>
+      </Dialog>
     </StyleRoot>
   );
 }

--- a/packages/sdk/src/anyspend/react/components/modals/EnterRecipientModal.tsx
+++ b/packages/sdk/src/anyspend/react/components/modals/EnterRecipientModal.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import { Dialog, DialogContent, Input, ShinyButton } from "@b3dotfun/sdk/global-account/react";
+import { useEffect, useState } from "react";
 
 export function EnterRecipientModal({
   isOpenPasteRecipientAddress,


### PR DESCRIPTION
## Summary
This PR enhances the AnySpend demo application by introducing a sign-in button component and allowing users to enter a custom recipient address for transactions. It improves user experience through modal dialogs and updates the recipient handling logic.

## Changes
• Added a new `SignInButton` component to facilitate user sign-in and account management using B3 SDK.
• Integrated the `SignInButton` into the main application layout for improved accessibility.
• Implemented a modal dialog for entering a custom recipient address, enhancing transaction flexibility.
• Updated recipient address handling to support custom addresses while maintaining existing functionality.