### PR TITLE
export tx hash on success

### DIFF
--- a/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
+++ b/packages/sdk/src/anyspend/react/components/AnySpendCustom.tsx
@@ -26,6 +26,9 @@ import {
 import {
   Badge,
   Button,
+  Dialog,
+  DialogContent,
+  Input,
   ShinyButton,
   Skeleton,
   StyleRoot,
@@ -43,9 +46,6 @@ import {
   useRouter,
   useSearchParamsSSR,
   useTokenBalancesByChain,
-  Dialog,
-  DialogContent,
-  Input,
 } from "@b3dotfun/sdk/global-account/react";
 import { cn } from "@b3dotfun/sdk/shared/utils";
 import centerTruncate from "@b3dotfun/sdk/shared/utils/centerTruncate";

--- a/packages/sdk/src/anyspend/react/components/AnyspendSignatureMint.tsx
+++ b/packages/sdk/src/anyspend/react/components/AnyspendSignatureMint.tsx
@@ -53,7 +53,7 @@ export function AnyspendSignatureMint({
   mode?: "modal" | "page";
   signatureData: GenerateSigMintResponse;
   imageUrl?: string;
-  onSuccess?: () => void;
+  onSuccess?: (txHash?: string) => void;
 }) {
   const hasMounted = useHasMounted();
 

--- a/packages/sdk/src/global-account/react/stores/useModalStore.ts
+++ b/packages/sdk/src/global-account/react/stores/useModalStore.ts
@@ -264,7 +264,7 @@ export interface AnySpendSignatureMintProps extends BaseModalProps {
   /** Optional image URL for NFT preview */
   imageUrl?: string;
   /** Callback function called when minting is successful */
-  onSuccess?: () => void;
+  onSuccess?: (txHash?: string) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR enhances the AnySpend component by modifying the success callback to include the transaction hash, improving the feedback provided to users upon successful transactions.

## Changes
• Updated the `onSuccess` callback in `AnyspendSignatureMint` to accept an optional transaction hash parameter. 