### PR TITLE
Cleanup imports and extract response schema

### DIFF
--- a/packages/sdk/src/anyspend/react/components/AnySpend.tsx
+++ b/packages/sdk/src/anyspend/react/components/AnySpend.tsx
@@ -27,7 +27,7 @@ import { ArrowDown, ChevronRightCircle, ChevronsUpDown, CircleAlert, ClipboardIc
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { parseUnits } from "viem";
-import { b3, b3Sepolia, base, mainnet, sepolia } from "viem/chains";
+import { b3Sepolia, base, mainnet, sepolia } from "viem/chains";
 import { OrderDetails, OrderDetailsLoadingView } from "./common/OrderDetails";
 import { OrderHistory } from "./common/OrderHistory";
 import { OrderStatus } from "./common/OrderStatus";
@@ -35,7 +35,6 @@ import { OrderTokenAmount } from "./common/OrderTokenAmount";
 import { PanelOnramp } from "./common/PanelOnramp";
 import { PanelOnrampPayment } from "./common/PanelOnrampPayment";
 import { TokenBalance } from "./common/TokenBalance";
-import { Warning } from "./common/Warning";
 import { EnterRecipientModal } from "./modals/EnterRecipientModal";
 
 export interface RecipientOption {

--- a/packages/sdk/src/anyspend/types/req-res/getOrderAndTransactions.ts
+++ b/packages/sdk/src/anyspend/types/req-res/getOrderAndTransactions.ts
@@ -8,16 +8,19 @@ export const zGetOrderAndTransactionsRequest = z.object({
   }),
 });
 
+export const zGetOrderAndTxsResponseData = z.object({
+  order: zOrder,
+  depositTxs: z.array(zDepositTransaction).nullable(),
+  relayTx: zRelayTransaction.nullable(),
+  executeTx: zExecuteTransaction.nullable(),
+  refundTxs: z.array(zRefundTransaction).nullable(),
+});
+export type GetOrderAndTxsResponseData = z.infer<typeof zGetOrderAndTxsResponseData>;
+
 export const zGetOrderAndTxsResponse = z.object({
   success: z.boolean(),
   message: z.string(),
-  data: z.object({
-    order: zOrder,
-    depositTxs: z.array(zDepositTransaction).nullable(),
-    relayTx: zRelayTransaction.nullable(),
-    executeTx: zExecuteTransaction.nullable(),
-    refundTxs: z.array(zRefundTransaction).nullable(),
-  }),
+  data: zGetOrderAndTxsResponseData,
   statusCode: z.number(),
 });
 export type GetOrderAndTxsResponse = z.infer<typeof zGetOrderAndTxsResponse>;

--- a/packages/sdk/src/global-account/react/components/StyleRoot.tsx
+++ b/packages/sdk/src/global-account/react/components/StyleRoot.tsx
@@ -3,6 +3,7 @@ import { useB3 } from "./B3Provider/useB3";
 
 export function StyleRoot({ children, id }: PropsWithChildren<{ id?: string }>) {
   const { theme: b3Theme } = useB3();
+
   return (
     <div className="b3-root" id={id} data-theme={b3Theme}>
       {children}


### PR DESCRIPTION
- Remove unused imports from AnySpend component
- Extract zGetOrderAndTxsResponseData schema and type for reusability
- Minor formatting improvements