### PR TITLE
Fix wallet authentication state management and update configs

### DIFF
--- a/apps/anyspend-demo-nextjs/README.md
+++ b/apps/anyspend-demo-nextjs/README.md
@@ -35,8 +35,8 @@ pnpm build
 Create a `.env.local` file with:
 
 ```env
-NEXT_PUBLIC_THIRDWEB_CLIENT_ID=eb17a5ec4314526d42fc567821aeb9a6
-NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID=ecosystem.b3dotfun
+NEXT_PUBLIC_THIRDWEB_CLIENT_ID=f393c7eb287696dc4db76d980cc68328
+NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID=ecosystem.b3-open-gaming
 ```
 
 ## Project Structure

--- a/apps/anyspend-demo-nextjs/next.config.js
+++ b/apps/anyspend-demo-nextjs/next.config.js
@@ -3,8 +3,8 @@ const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@b3dotfun/sdk"],
   env: {
-    NEXT_PUBLIC_THIRDWEB_CLIENT_ID: "eb17a5ec4314526d42fc567821aeb9a6",
-    NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID: "ecosystem.b3dotfun",
+    NEXT_PUBLIC_THIRDWEB_CLIENT_ID: "f393c7eb287696dc4db76d980cc68328",
+    NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID: "ecosystem.b3-open-gaming",
     NEXT_PUBLIC_THIRDWEB_PARTNER_ID: "68b6cf34-2699-42f6-8cbc-0d5ea40c6b52",
     NEXT_PUBLIC_B3_API: "https://api.b3.fun",
   },

--- a/apps/anyspend-demo-vite/README.md
+++ b/apps/anyspend-demo-vite/README.md
@@ -34,8 +34,8 @@ pnpm build
 Create a `.env` file with:
 
 ```env
-NEXT_PUBLIC_THIRDWEB_CLIENT_ID=eb17a5ec4314526d42fc567821aeb9a6
-NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID=ecosystem.b3dotfun
+NEXT_PUBLIC_THIRDWEB_CLIENT_ID=f393c7eb287696dc4db76d980cc68328
+NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID=ecosystem.b3-open-gaming
 ```
 
 ## Project Structure

--- a/apps/anyspend-demo-vite/vite.config.ts
+++ b/apps/anyspend-demo-vite/vite.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
   plugins: [react(), nodePolyfills(), viteCommonjs()],
   define: {
     "process.env": {
-      NEXT_PUBLIC_THIRDWEB_CLIENT_ID: "eb17a5ec4314526d42fc567821aeb9a6",
-      NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID: "ecosystem.b3dotfun",
+      NEXT_PUBLIC_THIRDWEB_CLIENT_ID: "f393c7eb287696dc4db76d980cc68328",
+      NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID: "ecosystem.b3-open-gaming",
     },
   },
   resolve: {

--- a/apps/login-minimal-example/vite.config.ts
+++ b/apps/login-minimal-example/vite.config.ts
@@ -1,45 +1,55 @@
 import { viteCommonjs } from "@originjs/vite-plugin-commonjs";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
 import path from "path";
 import { defineConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), nodePolyfills(), viteCommonjs()],
-  define: {
-    "process.env": {
-      NEXT_PUBLIC_THIRDWEB_CLIENT_ID: "eb17a5ec4314526d42fc567821aeb9a6",
-      NEXT_PUBLIC_DEVMODE_SHARED_SECRET: "k1c4Ep6agmoejiBinKE70B6bzb8vSdm8",
-      NEXT_PUBLIC_TRANSAK_API_KEY: "d1f4e8be-cacb-4cfa-b2cd-c591084b5ef6",
-      NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID: "ecosystem.b3dotfun",
-      NEXT_PUBLIC_THIRDWEB_PARTNER_ID: "ceba2f84-45ff-4717-b3e9-0acf0d062abd",
+export default defineConfig(({ command: _command }) => {
+  // Build env
+  // https://vite.dev/config/#conditional-config
+  let env = {};
+
+  // if (command === "serve") {
+  //   env = {
+  //     PUBLIC_B3_API: "http://localhost:3031",
+  //     PUBLIC_GLOBAL_ACCOUNTS_PARTNER_ID: "ceba2f84-45ff-4717-b3e9-0acf0d062abd", // Local dev
+  //     NEXT_PUBLIC_THIRDWEB_CLIENT_ID: "eb17a5ec4314526d42fc567821aeb9a6",
+  //     NEXT_PUBLIC_DEVMODE_SHARED_SECRET: "k1c4Ep6agmoejiBinKE70B6bzb8vSdm8",
+  //     NEXT_PUBLIC_TRANSAK_API_KEY: "d1f4e8be-cacb-4cfa-b2cd-c591084b5ef6",
+  //     NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID: "ecosystem.b3dotfun"
+  //   };
+  // } else {
+  env = {
+    PUBLIC_B3_API: "https://api.b3.fun",
+    PUBLIC_GLOBAL_ACCOUNTS_PARTNER_ID: "dbcd5e9b-564e-4ba0-91a0-becf0edabb61",
+    NEXT_PUBLIC_THIRDWEB_CLIENT_ID: "f393c7eb287696dc4db76d980cc68328",
+    NEXT_PUBLIC_DEVMODE_SHARED_SECRET: "k1c4Ep6agmoejiBinKE70B6bzb8vSdm8",
+    NEXT_PUBLIC_TRANSAK_API_KEY: "d1f4e8be-cacb-4cfa-b2cd-c591084b5ef6",
+    NEXT_PUBLIC_THIRDWEB_ECOSYSTEM_ID: "ecosystem.b3-open-gaming",
+  };
+  // }
+
+  const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+  return {
+    plugins: [react(), nodePolyfills(), viteCommonjs()],
+    define: {
+      "process.env": env,
     },
-  },
-  preview: {
-    allowedHosts: ["global-accounts-production.up.railway.app", "global.b3.fun"],
-  },
-  optimizeDeps: {
-    include: [
-      "@privy-io/public-api",
-      "@privy-io/react-auth",
-      "@walletconnect",
-      "@walletconnect/environment",
-      "@walletconnect/time",
-      "@walletconnect/logger",
-      "@walletconnect/types",
-      "@walletconnect/utils",
-      "@walletconnect/core",
-      "@walletconnect/sign-client",
-      "debug",
-      "hash.js",
-    ],
-    exclude: ["@b3dotfun/sdk", "thirdweb/react", "@radix-ui/react-slot"],
-  },
-  resolve: {
-    alias: {
-      "@b3dotfun/sdk/index.css": path.resolve(__dirname, "../../packages/sdk/dist/styles/index.css"),
-      "@b3dotfun/sdk": path.resolve(__dirname, "../../packages/sdk/src"),
+    preview: {
+      allowedHosts: ["global-accounts-production.up.railway.app", "global.b3.fun"],
     },
-  },
+    optimizeDeps: {
+      include: ["@b3dotfun/sdk"],
+      exclude: [],
+    },
+    resolve: {
+      alias: {
+        "@b3dotfun/sdk/index.css": path.resolve(__dirname, "../../packages/sdk/dist/styles/index.css"),
+        "@b3dotfun/sdk": path.resolve(__dirname, "../../packages/sdk/src"),
+      },
+    },
+  };
 });

--- a/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.native.tsx
+++ b/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.native.tsx
@@ -67,15 +67,10 @@ export function InnerProvider({
   theme: "light" | "dark";
 }) {
   const activeAccount = useActiveAccount();
-  const [manuallySetAccount, setManuallySetAccount] = useState<Account | undefined>(undefined);
   const [user, setUser] = useState<User | undefined>(undefined);
 
   // Use given accountOverride or activeAccount from thirdweb
-  const effectiveAccount = accountOverride || manuallySetAccount || activeAccount;
-
-  const setAccount = (account: Account) => {
-    setManuallySetAccount(account);
-  };
+  const effectiveAccount = accountOverride || activeAccount;
 
   return (
     <B3Context.Provider
@@ -84,7 +79,6 @@ export function InnerProvider({
         automaticallySetFirstEoa: false,
         setWallet: () => {},
         wallet: undefined,
-        setAccount,
         user,
         setUser,
         initialized: true,

--- a/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.tsx
+++ b/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.tsx
@@ -1,11 +1,17 @@
-import { TooltipProvider } from "@b3dotfun/sdk/global-account/react";
+import { TooltipProvider, useAuthStore } from "@b3dotfun/sdk/global-account/react";
 import { User } from "@b3dotfun/sdk/global-account/types/b3-api.types";
 import { PermissionsConfig } from "@b3dotfun/sdk/global-account/types/permissions";
 import { supportedChains } from "@b3dotfun/sdk/shared/constants/chains/supported";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 import { Toaster } from "sonner";
-import { ThirdwebProvider, useActiveAccount, useConnectedWallets, useSetActiveWallet } from "thirdweb/react";
+import {
+  getLastAuthProvider,
+  ThirdwebProvider,
+  useActiveAccount,
+  useConnectedWallets,
+  useSetActiveWallet,
+} from "thirdweb/react";
 import { Account, Wallet } from "thirdweb/wallets";
 import { createConfig, http, WagmiProvider } from "wagmi";
 import { RelayKitProviderWrapper } from "../RelayKitProviderWrapper";
@@ -94,50 +100,55 @@ export function InnerProvider({
   theme: "light" | "dark";
 }) {
   const activeAccount = useActiveAccount();
-  const [manuallySetAccount, setManuallySetAccount] = useState<Account | undefined>(undefined);
   const [manuallySelectedWallet, setManuallySelectedWallet] = useState<Wallet | undefined>(undefined);
   const wallets = useConnectedWallets();
   const setActiveWallet = useSetActiveWallet();
+  const isAuthenticated = useAuthStore(state => state.isAuthenticated);
 
   const [user, setUser] = useState<User | undefined>(undefined);
 
   // Use given accountOverride or activeAccount from thirdweb
-  const effectiveAccount = accountOverride || manuallySetAccount || activeAccount;
-
-  const setAccount = (account: Account) => {
-    setManuallySetAccount(account);
-  };
+  const effectiveAccount = isAuthenticated ? accountOverride || activeAccount : undefined;
 
   const setWallet = useCallback(
     (wallet: Wallet) => {
       setManuallySelectedWallet(wallet);
       const account = wallet.getAccount();
-      setManuallySetAccount(account);
       console.log("@@gio:setWallet", wallet.id, account?.address);
       setActiveWallet(wallet);
     },
-    [setManuallySelectedWallet, setManuallySetAccount, setActiveWallet],
+    [setManuallySelectedWallet, setActiveWallet],
   );
 
-  const setFirstEoa = useCallback(() => {
-    const firstEoa = wallets.find(wallet => ["com.coinbase.wallet", "io.metamask"].includes(wallet.id));
-    if (firstEoa) {
-      setWallet(firstEoa);
-    }
-  }, [setWallet, wallets]);
-
   useEffect(() => {
-    if (automaticallySetFirstEoa) {
-      console.log("@@gio:wallets", wallets);
-      setFirstEoa();
-    }
-  }, [automaticallySetFirstEoa, setFirstEoa, wallets]);
+    const autoSelectFirstEOAWallet = async () => {
+      // Only proceed if auto-selection is enabled and user is authenticated
+      if (!automaticallySetFirstEoa || !isAuthenticated) {
+        return;
+      }
+
+      // Find the first EOA wallet (excluding ecosystem wallets)
+      const isEOAWallet = (wallet: Wallet) => !wallet.id.startsWith("ecosystem.");
+      const firstEOAWallet = wallets.find(isEOAWallet);
+
+      if (firstEOAWallet) {
+        // Only auto-select if the last auth was via wallet or no previous auth provider
+        const lastAuthProvider = await getLastAuthProvider();
+        const shouldAutoSelect = lastAuthProvider === null || lastAuthProvider === "wallet";
+
+        if (shouldAutoSelect) {
+          setWallet(firstEOAWallet);
+        }
+      }
+    };
+
+    autoSelectFirstEOAWallet();
+  }, [automaticallySetFirstEoa, isAuthenticated, setWallet, wallets]);
 
   return (
     <B3Context.Provider
       value={{
         account: effectiveAccount,
-        setAccount,
         setWallet,
         wallet: manuallySelectedWallet,
         user,

--- a/packages/sdk/src/global-account/react/components/B3Provider/types.ts
+++ b/packages/sdk/src/global-account/react/components/B3Provider/types.ts
@@ -11,7 +11,6 @@ export interface B3ContextType {
   account?: Account;
   automaticallySetFirstEoa: boolean;
   user?: User;
-  setAccount: (account: Account) => void;
   setWallet: (wallet: Wallet) => void;
   wallet?: Wallet;
   setUser: (user?: User) => void;
@@ -29,7 +28,6 @@ export const B3Context = createContext<B3ContextType>({
   account: undefined,
   automaticallySetFirstEoa: false,
   user: undefined,
-  setAccount: () => {},
   setWallet: () => {},
   wallet: undefined,
   setUser: () => {},

--- a/packages/sdk/src/global-account/react/components/SignInWithB3/SignInWithB3.tsx
+++ b/packages/sdk/src/global-account/react/components/SignInWithB3/SignInWithB3.tsx
@@ -3,11 +3,11 @@ import {
   SignInWithB3ModalProps,
   StyleRoot,
   useAuthentication,
+  useB3,
   useIsMobile,
   useModalStore,
 } from "@b3dotfun/sdk/global-account/react";
 import { ReactNode, useEffect } from "react";
-import { useActiveAccount } from "thirdweb/react";
 import { ManageAccountButton } from "../custom/ManageAccountButton";
 import { Loading } from "../ui/Loading";
 
@@ -20,7 +20,7 @@ export type SignInWithB3Props = Omit<SignInWithB3ModalProps, "type" | "showBackB
 
 export function SignInWithB3(props: SignInWithB3Props) {
   const { setB3ModalOpen, setB3ModalContentType, setEcoSystemAccountAddress } = useModalStore();
-  const account = useActiveAccount();
+  const { account } = useB3();
   const { isAuthenticating, isAuthenticated } = useAuthentication(props.partnerId, props.loginWithSiwe);
   const isMobile = useIsMobile();
 

--- a/packages/sdk/src/global-account/react/components/SignInWithB3/steps/LoginStep.tsx
+++ b/packages/sdk/src/global-account/react/components/SignInWithB3/steps/LoginStep.tsx
@@ -113,11 +113,14 @@ export function LoginStep({ onSuccess, onError, partnerId, chain }: LoginStepPro
         onConnect={async wallet => {
           try {
             setIsAuthenticating(true);
-            console.log("connected!", wallet);
+
             const account = wallet.getAccount();
             if (!account) throw new Error("No account found");
+
             await onSuccess(account);
             setIsAuthenticated(true);
+
+            console.log("connected!", wallet.id);
           } catch (error) {
             await onError?.(error as Error);
             await logout();

--- a/packages/sdk/src/global-account/react/hooks/useAuthentication.ts
+++ b/packages/sdk/src/global-account/react/hooks/useAuthentication.ts
@@ -102,6 +102,7 @@ export function useAuthentication(partnerId: string, loginWithSiwe?: boolean) {
     if (typeof localStorage !== "undefined") {
       localStorage.removeItem("thirdweb:connected-wallet-ids");
       localStorage.removeItem("wagmi.store");
+      localStorage.removeItem("lastAuthProvider");
     }
 
     app.logout();


### PR DESCRIPTION
- Remove setAccount from B3Provider to maintain single source of truth where applications should use setWallet instead.
- Fix EOA wallet disconnect bug by properly checking isAuthenticated state and lastAuthProvider before auto-selecting wallets.
- Clear lastAuthProvider on logout because thirdweb doesn't automatically clear this for us, which was causing stale auth state when users switch between login methods (e.g. logging in with Google, logging out, then logging in again with SIWE would still think the last auth was Google).
- Update auto-selection logic to only select EOA wallets when user is authenticated and improve SignInWithB3 to use B3 context account instead of direct thirdweb hook.
- Also update Thirdweb client ID and ecosystem ID to b3-open-gaming across demo applications.