### PR TITLE
Remove redundant build steps from publish workflows

### DIFF
--- a/.github/workflows/publish-sdk-alpha.yml
+++ b/.github/workflows/publish-sdk-alpha.yml
@@ -81,11 +81,6 @@ jobs:
           echo "Next alpha version: $NEXT_VERSION"
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Build SDK package
-        run: |
-          cd packages/sdk
-          pnpm build
-
       - name: Run tests
         run: |
           cd packages/sdk

--- a/.github/workflows/publish-sdk-latest.yml
+++ b/.github/workflows/publish-sdk-latest.yml
@@ -39,11 +39,6 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Build SDK package
-        run: |
-          cd packages/sdk
-          pnpm build
-
       - name: Run tests
         run: |
           cd packages/sdk


### PR DESCRIPTION
- Remove explicit build step from publish-sdk-latest.yml workflow
- Remove explicit build step from publish-sdk-alpha.yml workflow
- Rely on prepublishOnly script in package.json which automatically builds before publish
- Improves CI performance by eliminating duplicate build execution