### PR TITLE
Fix onramp amount calculations and bigint handling

### DIFF
--- a/packages/sdk/src/anyspend/react/components/common/PanelOnrampPayment.tsx
+++ b/packages/sdk/src/anyspend/react/components/common/PanelOnrampPayment.tsx
@@ -6,7 +6,6 @@ import centerTruncate from "@b3dotfun/sdk/shared/utils/centerTruncate";
 import invariant from "invariant";
 import { ChevronLeft, ChevronRight, Landmark, Loader2 } from "lucide-react";
 import { motion } from "motion/react";
-import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AnySpendFingerprintWrapper, getFingerprintConfig } from "../AnySpendFingerprintWrapper";
 
@@ -64,17 +63,7 @@ function PanelOnrampPaymentInner(props: PanelOnrampPaymentProps) {
     recipientImageUrl,
   } = props;
 
-  // Use a stable amount for geo onramp options to prevent unnecessary refetches
-  const [stableAmountForGeo, setStableAmountForGeo] = useState(srcAmountOnRamp);
-  const hasInitialized = useRef(false);
-
-  // Only update the stable amount on first render or when explicitly needed
-  useEffect(() => {
-    if (!hasInitialized.current && srcAmountOnRamp) {
-      setStableAmountForGeo(srcAmountOnRamp);
-      hasInitialized.current = true;
-    }
-  }, [srcAmountOnRamp]);
+  console.log(`PanelOnrampPaymentInner:srcAmountOnRamp`, srcAmountOnRamp);
 
   const {
     geoData,
@@ -83,7 +72,7 @@ function PanelOnrampPaymentInner(props: PanelOnrampPaymentProps) {
     isStripeOnrampSupported,
     stripeWeb2Support,
     isLoading: isLoadingGeoOnramp,
-  } = useGeoOnrampOptions(isMainnet, stableAmountForGeo);
+  } = useGeoOnrampOptions(isMainnet, srcAmountOnRamp);
 
   const isLoading = isLoadingGeoOnramp;
 

--- a/packages/sdk/src/anyspend/react/components/webview/WebviewOnrampPayment.tsx
+++ b/packages/sdk/src/anyspend/react/components/webview/WebviewOnrampPayment.tsx
@@ -159,20 +159,10 @@ function WebviewOnrampPaymentInner({
   userId,
   partnerId,
 }: WebviewOnrampPaymentProps) {
-  const [stableAmountForGeo, setStableAmountForGeo] = useState(srcAmountOnRamp);
-  const hasInitialized = useRef(false);
   const [createdOrder, setCreatedOrder] = useState<components["schemas"]["Order"] | null>(null);
   const orderCreationAttempted = useRef(false);
 
-  // Only update the stable amount on first render or when explicitly needed
-  useEffect(() => {
-    if (!hasInitialized.current && srcAmountOnRamp) {
-      setStableAmountForGeo(srcAmountOnRamp);
-      hasInitialized.current = true;
-    }
-  }, [srcAmountOnRamp]);
-
-  const { geoData, stripeWeb2Support, isLoading: isLoadingGeoOnramp } = useGeoOnrampOptions(true, stableAmountForGeo);
+  const { geoData, stripeWeb2Support, isLoading: isLoadingGeoOnramp } = useGeoOnrampOptions(true, srcAmountOnRamp);
 
   const { createOrder, isCreatingOrder } = useAnyspendCreateOnrampOrder({
     onSuccess: data => {


### PR DESCRIPTION
- Fix bigint division error by using formatUnits instead of direct division
- Refactor geo onramp options to use calculated source amount
- Remove stable amount logic in favor of direct amount usage
- Use roundUpUSDCBaseAmountToNearest for proper amount rounding
- Simplify PanelOnrampPayment and WebviewOnrampPayment components