### PR TITLE
[B3-2205] Always show loading spinner

### DIFF
--- a/packages/sdk/src/global-account/react/components/ui/Loading.tsx
+++ b/packages/sdk/src/global-account/react/components/ui/Loading.tsx
@@ -16,7 +16,7 @@ export function Loading({ className, size = "md", variant = "white" }: LoadingPr
 
   const variantClass = {
     primary: "text-b3-react-primary",
-    white: "text-white opacity-50",
+    white: "opacity-50",
   }[variant];
 
   return (


### PR DESCRIPTION
B3-2205

## Description

The `text-white` class was preventing the loading spinner from showing

## Test Plan

- [x] Locally
- [ ] Unit Tests
- [x] Manually
- [ ] CI/CD

## Screenshots

For BE, include snippets, response payloads and/or curl commands to test endpoints

### [FE] Before

### [FE] After

<img width="1519" height="531" alt="Screenshot 2025-08-02 at 5 59 26 PM" src="https://github.com/user-attachments/assets/dea4cd3e-bf95-4101-961e-2770ccb9747c" />

### [BE] Snippets/Response/Curl

---

## automerge=false
