### PR TITLE
Dont redirect anyspend and format fees

### DIFF
--- a/packages/sdk/src/anyspend/react/components/common/FiatPaymentMethod.tsx
+++ b/packages/sdk/src/anyspend/react/components/common/FiatPaymentMethod.tsx
@@ -75,7 +75,7 @@ export function FiatPaymentMethodComponent({
       id: FiatPaymentMethod.STRIPE,
       name: "Stripe",
       description: "Credit or debit card payment",
-      badge: stripeFee ? `$${stripeFee} fee` : "Standard Fee",
+      badge: stripeFee ? `$${Number(stripeFee).toFixed(2)} fee` : "Standard Fee",
       badgeColor: "bg-yellow-100 text-yellow-800",
       available: true,
     });

--- a/packages/sdk/src/anyspend/react/components/common/PaymentStripeWeb2.tsx
+++ b/packages/sdk/src/anyspend/react/components/common/PaymentStripeWeb2.tsx
@@ -147,9 +147,7 @@ function StripePaymentForm({
     try {
       const result = (await stripe.confirmPayment({
         elements,
-        confirmParams: {
-          return_url: `${window.location.origin}/?orderId=${order.id}&waitingForDeposit=true&fromStripe=true`,
-        },
+        redirect: "if_required",
       })) as PaymentIntentResult;
 
       if (result.error) {


### PR DESCRIPTION
## Summary
This PR introduces enhancements to the payment processing components, specifically focusing on the display of fees and the handling of payment confirmations with Stripe.

## Changes
• Updated the fee display format in the `FiatPaymentMethodComponent` to ensure fees are shown with two decimal places for better clarity.
• Modified the payment confirmation process in `PaymentStripeWeb2` to use a conditional redirect instead of a fixed return URL, improving flexibility in handling payment outcomes