### PR TITLE
[B3-2240] Show first EOA balance in ManageAccount

### DIFF
--- a/packages/sdk/src/global-account/react/components/ManageAccount/ManageAccount.tsx
+++ b/packages/sdk/src/global-account/react/components/ManageAccount/ManageAccount.tsx
@@ -8,6 +8,7 @@ import {
   TWSignerWithMetadata,
   useAccountAssets,
   useAuthentication,
+  useB3,
   useB3BalanceFromAddresses,
   useGetAllTWSigners,
   useModalStore,
@@ -45,6 +46,7 @@ export function ManageAccount({
   chain,
   partnerId,
 }: ManageAccountProps) {
+  const { automaticallySetFirstEoa } = useB3();
   const [activeTab, setActiveTab] = useState("balance");
   const [revokingSignerId, setRevokingSignerId] = useState<string | null>(null);
   const account = useActiveAccount();
@@ -99,6 +101,20 @@ export function ManageAccount({
             <img src="https://cdn.b3.fun/b3_logo.svg" alt="B3" className="h-6 w-6" />
             <h2 className="font-neue-montreal-bold text-b3-react-primary text-lg">Global Account</h2>
           </div>
+
+          {!automaticallySetFirstEoa && (
+            <div className="mb-4">
+              <div className="flex items-center gap-4">
+                <img src="https://cdn.b3.fun/b3-coin-3d.png" alt="B3" className="h-10 w-10" />
+                <span className="font-neue-montreal-bold text-2xl">{b3Balance?.formattedTotal || "--"} B3</span>
+              </div>
+              <div className="border-b3-react-border my-4 border-t" />
+              <div className="flex items-center gap-4">
+                <img src="https://cdn.b3.fun/ethereum.svg" alt="ETH" className="h-10 w-10" />
+                <span className="font-neue-montreal-bold text-2xl">{nativeBalance?.formattedTotal || "--"} ETH</span>
+              </div>
+            </div>
+          )}
           <div className="flex flex-col gap-2">
             <p className="text-b3-react-secondary-foreground text-sm">Your universal account for all B3-powered apps</p>
             <div className="flex items-center gap-2">
@@ -112,22 +128,8 @@ export function ManageAccount({
       </div>
 
       <div className="border-b3-react-border bg-b3-react-subtle w-full rounded-lg border p-4">
-        <div className="mb-4">
-          <h3 className="font-neue-montreal-bold text-b3-react-primary mb-2">Smart Account Balance</h3>
-          <div className="flex items-center gap-4">
-            <img src="https://cdn.b3.fun/b3-coin-3d.png" alt="B3" className="h-10 w-10" />
-            <span className="font-neue-montreal-bold text-2xl">{eoaB3Balance?.formattedTotal || "--"} B3</span>
-          </div>
-          <div className="border-b3-react-border my-4 border-t" />
-          <div className="flex items-center gap-4">
-            <img src="https://cdn.b3.fun/ethereum.svg" alt="ETH" className="h-10 w-10" />
-            <span className="font-neue-montreal-bold text-2xl">{nativeBalance?.formattedTotal || "--"} ETH</span>
-          </div>
-        </div>
-
         {eoaAddress && (
           <>
-            <div className="border-b3-react-border my-4 border-t" />
             <div>
               <h3 className="font-neue-montreal-bold text-b3-react-primary mb-2">Connected {eoaInfo?.name}</h3>
               <div className="flex items-center gap-4">

--- a/packages/sdk/src/global-account/react/hooks/useFirstEOA.tsx
+++ b/packages/sdk/src/global-account/react/hooks/useFirstEOA.tsx
@@ -1,0 +1,41 @@
+import { useAuthStore } from "@b3dotfun/sdk/global-account/react";
+import { useEffect, useState } from "react";
+import { getLastAuthProvider, useConnectedWallets } from "thirdweb/react";
+import { Wallet } from "thirdweb/wallets";
+
+export default function useFirstEOA() {
+  const wallets = useConnectedWallets();
+  const isConnected = useAuthStore(state => state.isConnected);
+  const [firstEOA, setFirstEOA] = useState<Wallet | undefined>(undefined);
+  const [address, setAddress] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const autoSelectFirstEOAWallet = async () => {
+      // Only proceed if auto-selection is enabled and user is authenticated
+      if (!isConnected) {
+        return;
+      }
+
+      // Find the first EOA wallet (excluding ecosystem wallets)
+      const isEOAWallet = (wallet: Wallet) => !wallet.id.startsWith("ecosystem.");
+      const firstEOAWallet = wallets.find(isEOAWallet);
+
+      // Only auto-select if the last auth was via wallet or no previous auth provider
+      const lastAuthProvider = await getLastAuthProvider();
+      const shouldAutoSelect = lastAuthProvider === null || lastAuthProvider === "wallet";
+
+      if (shouldAutoSelect) {
+        const address = await firstEOAWallet?.getAccount();
+        setFirstEOA(firstEOAWallet);
+        setAddress(address?.address);
+      }
+    };
+
+    autoSelectFirstEOAWallet();
+  }, [isConnected, wallets]);
+
+  return {
+    account: firstEOA,
+    address,
+  };
+}

--- a/packages/sdk/src/global-account/react/hooks/useFirstEOA.tsx
+++ b/packages/sdk/src/global-account/react/hooks/useFirstEOA.tsx
@@ -1,6 +1,6 @@
 import { useAuthStore } from "@b3dotfun/sdk/global-account/react";
 import { useEffect, useState } from "react";
-import { getLastAuthProvider, useConnectedWallets } from "thirdweb/react";
+import { useConnectedWallets, useWalletInfo } from "thirdweb/react";
 import { Wallet } from "thirdweb/wallets";
 
 export default function useFirstEOA() {
@@ -8,27 +8,29 @@ export default function useFirstEOA() {
   const isConnected = useAuthStore(state => state.isConnected);
   const [firstEOA, setFirstEOA] = useState<Wallet | undefined>(undefined);
   const [address, setAddress] = useState<string | undefined>(undefined);
+  const walletInfo = useWalletInfo(firstEOA?.id);
+
+  console.log("@@wallets", wallets);
+  console.log("@@wallets:isConnected", isConnected);
 
   useEffect(() => {
     const autoSelectFirstEOAWallet = async () => {
       // Only proceed if auto-selection is enabled and user is authenticated
       if (!isConnected) {
+        console.log("@@wallets:not connected");
         return;
       }
 
       // Find the first EOA wallet (excluding ecosystem wallets)
       const isEOAWallet = (wallet: Wallet) => !wallet.id.startsWith("ecosystem.");
       const firstEOAWallet = wallets.find(isEOAWallet);
+      console.log("@@wallets:firstEOAWallet", firstEOAWallet);
 
-      // Only auto-select if the last auth was via wallet or no previous auth provider
-      const lastAuthProvider = await getLastAuthProvider();
-      const shouldAutoSelect = lastAuthProvider === null || lastAuthProvider === "wallet";
-
-      if (shouldAutoSelect) {
-        const address = await firstEOAWallet?.getAccount();
-        setFirstEOA(firstEOAWallet);
-        setAddress(address?.address);
-      }
+      const account = await firstEOAWallet?.getAccount();
+      console.log("@@wallets:account", account);
+      setFirstEOA(firstEOAWallet);
+      console.log("@@wallets:address", account?.address);
+      setAddress(account?.address);
     };
 
     autoSelectFirstEOAWallet();
@@ -37,5 +39,6 @@ export default function useFirstEOA() {
   return {
     account: firstEOA,
     address,
+    info: walletInfo,
   };
 }


### PR DESCRIPTION
B3-2240

## Description

Some apps are using EOA directly, so the smart account balance isn't as necessary. 

In this PR we do two things
- Show first EOA balance
- If `automaticallySetFirstEoa` is set, only show EOA balance
- If `automaticallySetFirstEoa` is not set, show both balances

## Test Plan

- [x] Locally
- [ ] Unit Tests
- [x] Manually
- [ ] CI/CD

## Screenshots

For BE, include snippets, response payloads and/or curl commands to test endpoints

### [FE] Before

### [FE] After

Without `automaticallySetFirstEoa`

<img width="595" height="887" alt="Screenshot 2025-08-05 at 1 39 47 PM" src="https://github.com/user-attachments/assets/674f1cba-24c6-448f-bfb8-d7c18321edf8" />

With `automaticallySetFirstEoa`

<img width="565" height="745" alt="Screenshot 2025-08-05 at 1 41 22 PM" src="https://github.com/user-attachments/assets/dedf4d10-5512-4a1f-84ca-1b266e0894bc" />


### [BE] Snippets/Response/Curl

---

## automerge=false
