### PR TITLE
[B3-2367] Referral information in ManageAccount modal

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -258,7 +258,7 @@
     "lint:fix": "eslint 'src/**/*.{ts,tsx}' --fix"
   },
   "dependencies": {
-    "@b3dotfun/b3-api": "0.0.43",
+    "@b3dotfun/b3-api": "0.0.45",
     "@b3dotfun/basement-api": "0.0.11",
     "@chakra-ui/react": "2.10.7",
     "@feathersjs/authentication-client": "5.0.33",

--- a/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.native.tsx
+++ b/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.native.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { ThirdwebProvider, useActiveAccount } from "thirdweb/react";
 import { Account } from "thirdweb/wallets";
 
-import { User } from "@b3dotfun/sdk/global-account/types/b3-api.types";
+import { Users } from "@b3dotfun/b3-api";
 import { B3Context, B3ContextType } from "./types";
 
 /**
@@ -64,7 +64,7 @@ export function InnerProvider({
   theme: "light" | "dark";
 }) {
   const activeAccount = useActiveAccount();
-  const [user, setUser] = useState<User | undefined>(undefined);
+  const [user, setUser] = useState<Users | undefined>(undefined);
 
   // Use given accountOverride or activeAccount from thirdweb
   const effectiveAccount = accountOverride || activeAccount;

--- a/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.tsx
+++ b/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.tsx
@@ -1,5 +1,4 @@
 import { RelayKitProviderWrapper, TooltipProvider, useAuthStore } from "@b3dotfun/sdk/global-account/react";
-import { User } from "@b3dotfun/sdk/global-account/types/b3-api.types";
 import { PermissionsConfig } from "@b3dotfun/sdk/global-account/types/permissions";
 import { loadGA4Script } from "@b3dotfun/sdk/global-account/utils/analytics";
 import { supportedChains } from "@b3dotfun/sdk/shared/constants/chains/supported";
@@ -18,6 +17,7 @@ import { createConfig, http, WagmiProvider } from "wagmi";
 import { StyleRoot } from "../StyleRoot";
 import { B3Context, B3ContextType } from "./types";
 
+import { Users } from "@b3dotfun/b3-api";
 import "@reservoir0x/relay-kit-ui/styles.css";
 
 /**
@@ -115,7 +115,7 @@ export function InnerProvider({
   const setActiveWallet = useSetActiveWallet();
   const isAuthenticated = useAuthStore(state => state.isAuthenticated);
 
-  const [user, setUser] = useState<User | undefined>(undefined);
+  const [user, setUser] = useState<Users | undefined>(undefined);
 
   // Use given accountOverride or activeAccount from thirdweb
   const effectiveAccount = isAuthenticated ? accountOverride || activeAccount : undefined;

--- a/packages/sdk/src/global-account/react/components/B3Provider/types.ts
+++ b/packages/sdk/src/global-account/react/components/B3Provider/types.ts
@@ -1,8 +1,7 @@
-import { Account } from "thirdweb/wallets";
-import { User } from "@b3dotfun/sdk/global-account/types/b3-api.types";
-import { Wallet } from "thirdweb/wallets";
+import { Users } from "@b3dotfun/b3-api";
 import { PermissionsConfig } from "@b3dotfun/sdk/global-account/types/permissions";
 import { createContext } from "react";
+import { Account, Wallet } from "thirdweb/wallets";
 
 /**
  * Context type for B3Provider
@@ -10,10 +9,10 @@ import { createContext } from "react";
 export interface B3ContextType {
   account?: Account;
   automaticallySetFirstEoa: boolean;
-  user?: User;
+  user?: Users;
   setWallet: (wallet: Wallet) => void;
   wallet?: Wallet;
-  setUser: (user?: User) => void;
+  setUser: (user?: Users) => void;
   initialized: boolean;
   ready: boolean;
   environment?: "development" | "production";

--- a/packages/sdk/src/global-account/react/components/ManageAccount/ManageAccount.tsx
+++ b/packages/sdk/src/global-account/react/components/ManageAccount/ManageAccount.tsx
@@ -29,7 +29,7 @@ import { getProfileDisplayInfo } from "../../utils/profileDisplay";
 import { AccountAssets } from "../AccountAssets/AccountAssets";
 import { ContentTokens } from "./ContentTokens";
 
-import { Referrals } from "@b3dotfun/b3-api";
+import { Referrals, Users } from "@b3dotfun/b3-api";
 import { BalanceContent } from "./BalanceContent";
 
 type TabValue = "overview" | "tokens" | "nfts" | "apps" | "settings";
@@ -168,7 +168,7 @@ export function ManageAccount({
           userId: user?.userId,
           referralCode: newReferralCode,
         });
-        setUser(newUser);
+        setUser(newUser as Users);
         toast.success("Referral code updated successfully!");
         setIsEditingCode(false);
         setNewReferralCode("");

--- a/packages/sdk/src/global-account/react/components/ManageAccount/ManageAccount.tsx
+++ b/packages/sdk/src/global-account/react/components/ManageAccount/ManageAccount.tsx
@@ -19,7 +19,7 @@ import { SignOutIcon } from "@b3dotfun/sdk/global-account/react/components/icons
 import { formatNumber } from "@b3dotfun/sdk/shared/utils/formatNumber";
 import { client } from "@b3dotfun/sdk/shared/utils/thirdweb";
 import { BarChart3, Coins, Copy, Image, LinkIcon, Loader2, Pencil, Settings, UnlinkIcon } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { Chain } from "thirdweb";
 import { useActiveAccount, useProfiles, useUnlinkProfile } from "thirdweb/react";
@@ -138,6 +138,7 @@ export function ManageAccount({
     const [isUpdatingCode, setIsUpdatingCode] = useState(false);
     const [newReferralCode, setNewReferralCode] = useState("");
     const [isEditingCode, setIsEditingCode] = useState(false);
+    const referallCodeRef = useRef<HTMLInputElement>(null);
     const { data: referrals, isLoading: isLoadingReferrals } = useQueryB3(
       "referrals",
       "find",
@@ -294,13 +295,23 @@ export function ManageAccount({
 
           {/* Referral Code */}
           <div className="bg-b3-line rounded-xl p-4">
-            <div className="flex items-center justify-between">
+            {isEditingCode && (
               <div>
                 <div className="text-b3-grey font-neue-montreal-semibold">Your Referral Code</div>
                 <div className="text-b3-foreground-muted font-neue-montreal-medium text-sm">
                   Share this code with friends to earn rewards
                 </div>
               </div>
+            )}
+            <div className="flex items-center justify-between">
+              {!isEditingCode && (
+                <div>
+                  <div className="text-b3-grey font-neue-montreal-semibold">Your Referral Code</div>
+                  <div className="text-b3-foreground-muted font-neue-montreal-medium text-sm">
+                    Share this code with friends to earn rewards
+                  </div>
+                </div>
+              )}
               <div className="flex items-center gap-2">
                 {isEditingCode ? (
                   <div className="flex items-center gap-2">
@@ -310,6 +321,7 @@ export function ManageAccount({
                       onChange={e => setNewReferralCode(e.target.value)}
                       className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm"
                       placeholder="Enter new code"
+                      ref={referallCodeRef}
                     />
                     <Button size="sm" onClick={handleUpdateReferralCode} disabled={isUpdatingCode || !newReferralCode}>
                       {isUpdatingCode ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save"}
@@ -333,7 +345,16 @@ export function ManageAccount({
                     <Button size="icon" variant="ghost" onClick={handleCopyCode}>
                       <Copy className="h-4 w-4" />
                     </Button>
-                    <Button size="icon" variant="ghost" onClick={() => setIsEditingCode(true)}>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => {
+                        setIsEditingCode(true);
+                        setTimeout(() => {
+                          referallCodeRef.current?.focus();
+                        }, 100);
+                      }}
+                    >
                       <Pencil className="h-4 w-4" />
                     </Button>
                   </>

--- a/packages/sdk/src/global-account/react/components/ManageAccount/ManageAccount.tsx
+++ b/packages/sdk/src/global-account/react/components/ManageAccount/ManageAccount.tsx
@@ -168,7 +168,7 @@ export function ManageAccount({
           userId: user?.userId,
           referralCode: newReferralCode,
         });
-        setUser(newUser as Users);
+        setUser(newUser as unknown as Users);
         toast.success("Referral code updated successfully!");
         setIsEditingCode(false);
         setNewReferralCode("");

--- a/packages/sdk/src/global-account/react/hooks/useSiwe.tsx
+++ b/packages/sdk/src/global-account/react/hooks/useSiwe.tsx
@@ -5,13 +5,13 @@ import { Account } from "thirdweb/wallets";
 import { useSearchParam } from "./useSearchParamsSSR";
 
 export function useSiwe() {
-  const referrerId = useSearchParam("referrerId");
+  const referralCode = useSearchParam("referralCode");
 
   const authenticate = useCallback(
     async (account: Account, partnerId: string) => {
       if (!account || !account.signMessage) throw new Error("Account not found");
 
-      console.log("@@useAuthenticate:referrerId", referrerId);
+      console.log("@@useAuthenticate:referralCode", referralCode);
       // generate challenge
       const challenge = await app.service("global-accounts-challenge").create({
         address: account.address,
@@ -32,15 +32,15 @@ export function useSiwe() {
         signature,
         serverSignature: challenge.serverSignature,
         nonce: challenge.nonce,
-        // http://localhost:5173/?referrerId=cd8fda06-3840-43d3-8f35-ae9472a13759
-        referrerId: referrerId,
+        // http://localhost:5173/?referralCode=GIO2
+        referralCode,
         partnerId: partnerId,
       });
       debug("@@useAuthenticate:response", response);
 
       return response;
     },
-    [referrerId],
+    [referralCode],
   );
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,8 +525,8 @@ importers:
   packages/sdk:
     dependencies:
       '@b3dotfun/b3-api':
-        specifier: 0.0.43
-        version: 0.0.43(@types/node@22.14.0)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(bufferutil@4.0.9)(debug@4.4.1)(encoding@0.1.13)(h3@1.15.4)(next@14.1.0(@babel/core@7.28.0)(@opentelemetry/api@1.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native@0.80.2(@babel/core@7.28.0)(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(socks@2.8.7)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.75)
+        specifier: 0.0.45
+        version: 0.0.45(@types/node@22.14.0)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(bufferutil@4.0.9)(debug@4.4.1)(encoding@0.1.13)(h3@1.15.4)(next@14.1.0(@babel/core@7.28.0)(@opentelemetry/api@1.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native@0.80.2(@babel/core@7.28.0)(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(socks@2.8.7)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.75)
       '@b3dotfun/basement-api':
         specifier: 0.0.11
         version: 0.0.11(bufferutil@4.0.9)(debug@4.4.1)(encoding@0.1.13)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@4.21.2)(graphql@16.11.0)(h3@1.15.4)(koa@3.0.1)(next@14.1.0(@babel/core@7.28.0)(@opentelemetry/api@1.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(socks@2.8.7)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.75)
@@ -995,8 +995,8 @@ packages:
     resolution: {integrity: sha512-6Ed0kmC1NMbuFTEgNmamAUU1h5gShgxL1hBVLbEzUa3trX5aJBz1vU4bXaBTvOYUAnOHtiy1Ml4AMStd6hJnFA==}
     engines: {node: '>=18.0.0'}
 
-  '@b3dotfun/b3-api@0.0.43':
-    resolution: {integrity: sha512-+fKIWnILt2ToHE4+0XhogoPHBGfHd5hz0XFfHPfGdQBiqklT9+tgaIK+cIzWWBPomQLTugMM/t7D/GONmy3Flw==}
+  '@b3dotfun/b3-api@0.0.45':
+    resolution: {integrity: sha512-p5fm9k8jPyZY/HuuEXku3amP5L2hoSHJN1MfW5wpNx9Xngk/974jD0JsEs9w1W1mUoaC3Xe8ZjGfbVUfTgHxKQ==}
     engines: {node: '>= 20.15.0'}
 
   '@b3dotfun/basement-api@0.0.11':
@@ -13228,7 +13228,7 @@ snapshots:
       '@smithy/types': 4.3.2
       tslib: 2.8.1
 
-  '@b3dotfun/b3-api@0.0.43(@types/node@22.14.0)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(bufferutil@4.0.9)(debug@4.4.1)(encoding@0.1.13)(h3@1.15.4)(next@14.1.0(@babel/core@7.28.0)(@opentelemetry/api@1.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native@0.80.2(@babel/core@7.28.0)(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(socks@2.8.7)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.75)':
+  '@b3dotfun/b3-api@0.0.45(@types/node@22.14.0)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(bufferutil@4.0.9)(debug@4.4.1)(encoding@0.1.13)(h3@1.15.4)(next@14.1.0(@babel/core@7.28.0)(@opentelemetry/api@1.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native@0.80.2(@babel/core@7.28.0)(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(socks@2.8.7)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.75)':
     dependencies:
       '@apollo/client': 3.13.9(@types/react@19.1.0)(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@feathersjs/adapter-commons': 5.0.34


### PR DESCRIPTION
B3-2367

## Description

- Adds a place for referral information in ManageAccount modal
- Adds an input to set a new referral code
- Adds a section to show users you've referred

## Test Plan

- [x] Locally
- [ ] Unit Tests
- [x] Manually
- [ ] CI/CD

## Screenshots

For BE, include snippets, response payloads and/or curl commands to test endpoints

### [FE] Before

### [FE] After

https://github.com/user-attachments/assets/3b195c65-eb37-4118-aecc-ff47a1446319


### [BE] Snippets/Response/Curl

---

## automerge=false
