### PR TITLE
[Trivial] [B3-2591] Disable Wagmi's default reconnectOnMount

### DIFF
--- a/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.tsx
+++ b/packages/sdk/src/global-account/react/components/B3Provider/B3Provider.tsx
@@ -111,7 +111,7 @@ export function B3Provider({
 
   return (
     <ThirdwebProvider>
-      <WagmiProvider config={wagmiConfig}>
+      <WagmiProvider config={wagmiConfig} reconnectOnMount={false}>
         <QueryClientProvider client={queryClient}>
           <TooltipProvider>
             <InnerProvider


### PR DESCRIPTION
B3-2591

## Description

We have recently found that we are making several calls to "accounts" from TW. One of them often fails, being the one that's initiated from the WagmiProvider

In an effort to minimize this, we are disabling Wagmi's default reconnectOnMount, and relying Solely on the hooks and methods TW provides via useAuthenticate & <ConnectEmbed autoConnect={true} />



## Test Plan

- [x] Locally
- [ ] Unit Tests
- [x] Manually
- [ ] CI/CD

## Screenshots

For BE, include snippets, response payloads and/or curl commands to test endpoints

### [FE] Before

<img width="1050" height="679" alt="Screen Shot 2025-09-25 at 7 22 07 PM" src="https://github.com/user-attachments/assets/2072d5f9-3357-48c5-969d-cfb5114b420d" />
<img width="1028" height="674" alt="Screen Shot 2025-09-25 at 7 22 02 PM" src="https://github.com/user-attachments/assets/0d61c52e-040c-4064-8ba7-9ceb8fe53cb8" />
<img width="991" height="646" alt="Screen Shot 2025-09-25 at 7 21 53 PM" src="https://github.com/user-attachments/assets/058756f2-5fc6-4549-87c5-c5fbe9fc7df5" />

### [FE] After
<img width="1109" height="735" alt="Screen Shot 2025-09-25 at 9 05 07 PM" src="https://github.com/user-attachments/assets/8975f148-991a-4dc2-9877-716ae95917c1" />


### [BE] Snippets/Response/Curl

---

## automerge=false
