### PR TITLE
default to 6 decimals for fiat

### DIFF
--- a/packages/sdk/src/anyspend/react/hooks/useAnyspendFlow.ts
+++ b/packages/sdk/src/anyspend/react/hooks/useAnyspendFlow.ts
@@ -157,7 +157,9 @@ export function useAnyspendFlow({
   };
 
   // Get quote
-  const activeInputAmountInWei = parseUnits(srcAmount.replace(/,/g, ""), selectedSrcToken.decimals).toString();
+  // For fiat payments, always use USDC decimals (6) regardless of selectedSrcToken
+  const effectiveDecimals = paymentType === "fiat" ? USDC_BASE.decimals : selectedSrcToken.decimals;
+  const activeInputAmountInWei = parseUnits(srcAmount.replace(/,/g, ""), effectiveDecimals).toString();
   const { anyspendQuote, isLoadingAnyspendQuote, getAnyspendQuoteError } = useAnyspendQuote({
     srcChain: paymentType === "fiat" ? base.id : selectedSrcChainId,
     dstChain: isDepositMode ? base.id : selectedDstChainId, // For deposits, always Base; for swaps, use selected destination


### PR DESCRIPTION
## Summary
This PR implements a change to default to 6 decimal places for fiat transactions in the Anyspend flow, enhancing consistency in handling fiat payments. Additionally, it includes updates to the API and refactors certain payload structures.

## Changes
• Updated the handling of fiat payments to always use USDC decimals (6) for input amounts, ensuring uniformity across transactions.  
• Modified the API to remove the `amountInAfterFee` field from the payload structure, simplifying the response.  