### PR TITLE
add hooks to get global account

### DIFF
--- a/packages/sdk/src/global-account/react/hooks/index.ts
+++ b/packages/sdk/src/global-account/react/hooks/index.ts
@@ -14,6 +14,7 @@ export { useExchangeRate } from "./useExchangeRate";
 export { useFirstEOA } from "./useFirstEOA";
 export { useGetAllTWSigners, type TWSignerWithMetadata } from "./useGetAllTWSigners";
 export { useGetGeo } from "./useGetGeo";
+export { useGlobalAccount } from "./useGlobalAccount";
 export { useHandleConnectWithPrivy } from "./useHandleConnectWithPrivy";
 export { useHasMounted } from "./useHasMounted";
 export { useIsMobile } from "./useIsMobile";

--- a/packages/sdk/src/global-account/react/hooks/useGlobalAccount.tsx
+++ b/packages/sdk/src/global-account/react/hooks/useGlobalAccount.tsx
@@ -1,0 +1,41 @@
+import { useAuthStore } from "@b3dotfun/sdk/global-account/react";
+import { debugB3React } from "@b3dotfun/sdk/shared/utils/debug";
+import { useEffect, useState } from "react";
+import { useConnectedWallets, useWalletInfo } from "thirdweb/react";
+import { Wallet } from "thirdweb/wallets";
+
+const debug = debugB3React("useGlobalAccount");
+
+export function useGlobalAccount() {
+  const wallets = useConnectedWallets();
+  const isConnected = useAuthStore(state => state.isConnected);
+  const [globalAccount, setGlobalAccount] = useState<Wallet | undefined>(undefined);
+  const [address, setAddress] = useState<string | undefined>(undefined);
+  const walletInfo = useWalletInfo(globalAccount?.id);
+
+  useEffect(() => {
+    const autoSelectGlobalAccount = async () => {
+      // Only proceed if auto-selection is enabled and user is authenticated
+      if (!isConnected) {
+        debug("Not connected");
+        return;
+      }
+
+      // Find the first ecosystem wallet (global account)
+      const isEcosystemWallet = (wallet: Wallet) => wallet.id.startsWith("ecosystem.");
+      const globalAccountWallet = wallets.find(isEcosystemWallet);
+
+      const account = globalAccountWallet?.getAccount();
+      setGlobalAccount(globalAccountWallet);
+      setAddress(account?.address);
+    };
+
+    autoSelectGlobalAccount();
+  }, [isConnected, wallets]);
+
+  return {
+    account: globalAccount,
+    address,
+    info: walletInfo,
+  };
+}


### PR DESCRIPTION
## Summary
This PR introduces a new hook, `useGlobalAccount`, which facilitates the automatic selection of a global account from connected wallets, enhancing the user experience in managing wallet connections.

## Changes
• Added a new hook `useGlobalAccount` to manage and retrieve the user's global account from connected wallets.  
• Integrated logic to automatically select the first ecosystem wallet when the user is authenticated.  