### PR TITLE
fix: update InsufficientDepositPayment display condition

### DIFF
--- a/packages/sdk/src/anyspend/react/components/common/OrderDetails.tsx
+++ b/packages/sdk/src/anyspend/react/components/common/OrderDetails.tsx
@@ -988,7 +988,7 @@ export const OrderDetails = memo(function OrderDetails({
         </Accordion>
 
         {/* Show payment UI when deposit is not enough and order is not expired */}
-        {!depositEnoughAmount && order.status !== "expired" && (
+        {depositTxs?.length > 0 && !depositEnoughAmount && order.status === "scanning_deposit_transaction" && (
           <InsufficientDepositPayment
             order={order}
             srcToken={srcToken}


### PR DESCRIPTION
- Only show when deposit transactions exist
- Restrict to scanning_deposit_transaction status
- Add depositTxs length check for better UX

[LINEAR_ISSUE_ID_HERE]

## Description

Write a description.

## Test Plan

- [ ] Locally
- [ ] Unit Tests
- [ ] Manually
- [ ] CI/CD

## Screenshots

For BE, include snippets, response payloads and/or curl commands to test endpoints

### [FE] Before

### [FE] After

### [BE] Snippets/Response/Curl

---

## automerge=false
